### PR TITLE
Switch self.buffer.render to an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function ChooHooks (emitter) {
   this.listeners = {}
   this.buffer = {
     use: [],
-    render: [],
+    render: {},
     events: {}
   }
 }
@@ -44,11 +44,11 @@ ChooHooks.prototype.start = function () {
 
     var eventName = timing.name
     if (/choo\.morph/.test(eventName)) {
-      self.buffer.render.push(timing)
+      self.buffer.render.morph = timing
     } else if (/choo\.route/.test(eventName)) {
-      self.buffer.render.push(timing)
+      self.buffer.render.route = timing
     } else if (/choo\.render/.test(eventName)) {
-      self.buffer.render.push(timing)
+      self.buffer.render.render = timing
     } else if (/choo\.use/.test(eventName)) {
       self.buffer.use.push(timing)
     } else if (/choo\.emit/.test(eventName) && !/log:/.test(eventName)) {
@@ -65,7 +65,8 @@ ChooHooks.prototype.start = function () {
       }
     }
 
-    if (self.buffer.render.length === 3) {
+    var rBuf = self.buffer.render
+    if (rBuf.render && rBuf.route && rBuf.morph) {
       var renderListener = self.listeners['render']
       if (!renderListener) return
       var timings = {}
@@ -76,6 +77,7 @@ ChooHooks.prototype.start = function () {
         else if (/choo\.morph/.test(name)) timings.morph = _timing
         else timings.route = _timing
       }
+      rBuf.render = rBuf.route = rBuf.morph = void 0
       renderListener(timings)
     }
   })


### PR DESCRIPTION
Sometimes self.buffer.render has three objects pushed into it, but they aren't
the complete set of render, route & morph objects that we want when we call
the render listener.

This switches to using an object to store this data instead, which mimics the
original behavior (last-in-wins) but allows us to expressly check to see
if all the data necessary is present before calling the listener

Fixes #3 and obsoletes choojs/choo-devtools#23