### PR TITLE
fix log message arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,9 @@ ChooHooks.prototype.start = function () {
       logLevel = logLevel[1]
       // Log:*
       var logListener = self.listeners['log:' + logLevel]
-      if (logListener) logListener(eventName, data)
+      if (logListener) {
+        logListener.apply(null, Array.prototype.slice.call(arguments, 0, arguments.length - 1))
+      }
     } else if (!self.emitter.listeners(eventName).length) {
       // Unhandled
       var unhandledListener = self.listeners['unhandled']


### PR DESCRIPTION
For a long time I have wondered why log messages (e.g. `log:debug`) never include any argument after the first one.

For example:

```
emit('log:debug', 'debug message', { data: 'important data' })
emit('log:debug', 'debug message')
```

In latest choo, the two statements above produce the same output (the third argument is dropped).

Today, I finally figured it out. The problem is nested deeply inside `choo-hooks`!

This PR passes all arguments from the emitter (except for the event uuid) to the log handler.

This goose hunt also led me to notice `choo.emit` has the same issue in `choo-devtools`.

https://github.com/choojs/choo-devtools/blob/master/index.js#L30-L32