### PR TITLE
remove use hook (no longer working)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ Listen for service worker event.
 ### `hook.on('event', cb(eventName, timing, data))`
 Called for events implemented at the application layer.
 
-### `hook.on('use', cb(count, duration))`
-Called whenever `app.use()` is called.
-
 ### `hook.on('unhandled', cb(eventName, data))`
 Called whenever an event is emitted, and there is no handler available.
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ function ChooHooks (emitter) {
   this.emitter = emitter
   this.listeners = {}
   this.buffer = {
-    use: [],
     render: {},
     events: {}
   }
@@ -49,8 +48,6 @@ ChooHooks.prototype.start = function () {
       self.buffer.render.route = timing
     } else if (/choo\.render/.test(eventName)) {
       self.buffer.render.render = timing
-    } else if (/choo\.use/.test(eventName)) {
-      self.buffer.use.push(timing)
     } else if (/choo\.emit/.test(eventName) && !/log:/.test(eventName)) {
       var eventListener = self.listeners['event']
       if (eventListener) {
@@ -118,8 +115,6 @@ ChooHooks.prototype._emitLoaded = function () {
   var self = this
   scheduler.push(function clear () {
     var listener = self.listeners['DOMContentLoaded']
-    var usesListener = self.listeners['use']
-
     var timing = self.hasWindow && window.performance && window.performance.timing
 
     if (listener && timing) {
@@ -128,18 +123,5 @@ ChooHooks.prototype._emitLoaded = function () {
         loaded: timing.domContentLoadedEventEnd - timing.navigationStart
       })
     }
-
-    if (self.hasPerformance) {
-      var duration = sumDurations(self.buffer.use)
-      if (usesListener) usesListener(self.buffer.use.length, duration)
-    } else {
-      usesListener()
-    }
   })
-}
-
-function sumDurations (timings) {
-  return timings.reduce(function (sum, timing) {
-    return sum + timing.duration
-  }, 0).toFixed()
 }


### PR DESCRIPTION
Removes an outdated listener call that no longer reports accurate information due to store ordering changes in 6.x

Companion to https://github.com/choojs/choo-devtools/pull/39

See also https://github.com/choojs/choo-devtools/issues/38