### PR TITLE
chore(ci): target latest stable & LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-node_js:
-- "4"
-- "5"
-- "6"
-- "7"
-sudo: false
+dist: xenial
 language: node_js
-script: "npm run test"
-# after_success: "npm i -g codecov && npm run coverage && codecov"
+node_js:
+  - 'node'
+  - 'lts/*'


### PR DESCRIPTION
erring on the side of matching choo config and removing anything unnecessary
- use xenial dist
- target latest & LTS node
- rely on default install and test scripts for node